### PR TITLE
Frobenius

### DIFF
--- a/bls12_381.go
+++ b/bls12_381.go
@@ -114,7 +114,7 @@ var g2One = PointG2{
 var G2One = g2One
 
 /*
-	Frobenious Coeffs
+	Frobenius Coeffs
 */
 
 var frobeniusCoeffs2 = [2]fe{

--- a/fp2.go
+++ b/fp2.go
@@ -201,7 +201,7 @@ func (e *fp2) exp(c, a *fe2, s *big.Int) {
 	c.set(z)
 }
 
-func (e *fp2) frobeniousMap(c, a *fe2, power uint) {
+func (e *fp2) frobeniusMap(c, a *fe2, power uint) {
 	c[0].set(&a[0])
 	if power%2 == 1 {
 		neg(&c[1], &a[1])
@@ -210,7 +210,7 @@ func (e *fp2) frobeniousMap(c, a *fe2, power uint) {
 	c[1].set(&a[1])
 }
 
-func (e *fp2) frobeniousMapAssign(a *fe2, power uint) {
+func (e *fp2) frobeniusMapAssign(a *fe2, power uint) {
 	if power%2 == 1 {
 		neg(&a[1], &a[1])
 		return

--- a/fp6.go
+++ b/fp6.go
@@ -305,9 +305,9 @@ func (e *fp6) inverse(c, a *fe6) {
 
 func (e *fp6) frobeniusMap(c, a *fe6, power uint) {
 	fp2 := e.fp2
-	fp2.frobeniousMap(&c[0], &a[0], power)
-	fp2.frobeniousMap(&c[1], &a[1], power)
-	fp2.frobeniousMap(&c[2], &a[2], power)
+	fp2.frobeniusMap(&c[0], &a[0], power)
+	fp2.frobeniusMap(&c[1], &a[1], power)
+	fp2.frobeniusMap(&c[2], &a[2], power)
 	switch power % 6 {
 	case 0:
 		return
@@ -323,9 +323,9 @@ func (e *fp6) frobeniusMap(c, a *fe6, power uint) {
 
 func (e *fp6) frobeniusMapAssign(a *fe6, power uint) {
 	fp2 := e.fp2
-	fp2.frobeniousMapAssign(&a[0], power)
-	fp2.frobeniousMapAssign(&a[1], power)
-	fp2.frobeniousMapAssign(&a[2], power)
+	fp2.frobeniusMapAssign(&a[0], power)
+	fp2.frobeniusMapAssign(&a[1], power)
+	fp2.frobeniusMapAssign(&a[2], power)
 	t := e.t
 	switch power % 6 {
 	case 0:

--- a/g1.go
+++ b/g1.go
@@ -53,7 +53,7 @@ func (g *G1) Q() *big.Int {
 	return new(big.Int).Set(q)
 }
 
-// FromUncompressed expects byte slice larger than 96 bytes and given bytes returns a new point in G1.
+// FromUncompressed expects byte slice at least 96 bytes and given bytes returns a new point in G1.
 // Serialization rules are in line with zcash library. See below for details.
 // https://github.com/zcash/librustzcash/blob/master/pairing/src/bls12_381/README.md#serialization
 // https://docs.rs/bls12_381/0.1.1/bls12_381/notes/serialization/index.html
@@ -113,7 +113,7 @@ func (g *G1) ToUncompressed(p *PointG1) []byte {
 	return out
 }
 
-// FromCompressed expects byte slice larger than 96 bytes and given bytes returns a new point in G1.
+// FromCompressed expects byte slice at least 48 bytes and given bytes returns a new point in G1.
 // Serialization rules are in line with zcash library. See below for details.
 // https://github.com/zcash/librustzcash/blob/master/pairing/src/bls12_381/README.md#serialization
 // https://docs.rs/bls12_381/0.1.1/bls12_381/notes/serialization/index.html
@@ -194,7 +194,7 @@ func (g *G1) fromBytesUnchecked(in []byte) (*PointG1, error) {
 
 // FromBytes constructs a new point given uncompressed byte input.
 // FromBytes does not take zcash flags into account.
-// Byte input expected to be larger than 96 bytes.
+// Byte input expected to be at least 96 bytes.
 // First 96 bytes should be concatenation of x and y values.
 // Point (0, 0) is considered as infinity.
 func (g *G1) FromBytes(in []byte) (*PointG1, error) {

--- a/g2.go
+++ b/g2.go
@@ -63,7 +63,7 @@ func (g *G2) Q() *big.Int {
 	return new(big.Int).Set(q)
 }
 
-// FromUncompressed expects byte slice larger than 192 bytes and given bytes returns a new point in G2.
+// FromUncompressed expects byte slice at least 192 bytes and given bytes returns a new point in G2.
 // Serialization rules are in line with zcash library. See below for details.
 // https://github.com/zcash/librustzcash/blob/master/pairing/src/bls12_381/README.md#serialization
 // https://docs.rs/bls12_381/0.1.1/bls12_381/notes/serialization/index.html
@@ -123,7 +123,7 @@ func (g *G2) ToUncompressed(p *PointG2) []byte {
 	return out
 }
 
-// FromCompressed expects byte slice larger than 96 bytes and given bytes returns a new point in G2.
+// FromCompressed expects byte slice at least 96 bytes and given bytes returns a new point in G2.
 // Serialization rules are in line with zcash library. See below for details.
 // https://github.com/zcash/librustzcash/blob/master/pairing/src/bls12_381/README.md#serialization
 // https://docs.rs/bls12_381/0.1.1/bls12_381/notes/serialization/index.html
@@ -204,7 +204,7 @@ func (g *G2) fromBytesUnchecked(in []byte) (*PointG2, error) {
 
 // FromBytes constructs a new point given uncompressed byte input.
 // FromBytes does not take zcash flags into account.
-// Byte input expected to be larger than 96 bytes.
+// Byte input expected to be at least 192 bytes.
 // First 192 bytes should be concatenation of x and y values
 // Point (0, 0) is considered as infinity.
 func (g *G2) FromBytes(in []byte) (*PointG2, error) {


### PR DESCRIPTION
# What has been changed

Minor spelling updates to `Frobenious` -> `Frobenius`.

Update comments to correct number of bytes required for deserialisation methods.