### PR TITLE
Allow any xmd hash in to curve conversion.

### DIFF
--- a/g1.go
+++ b/g1.go
@@ -642,8 +642,9 @@ func (g *G1) MapToCurve(in []byte) (*PointG1, error) {
 // which is a valid curve point.
 // Implementation follows BLS12381G1_XMD:SHA-256_SSWU_NU_ suite at
 // https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-06
-func (g *G1) EncodeToCurve(msg, domain []byte) (*PointG1, error) {
-	hashRes, err := hashToFpXMDSHA256(msg, domain, 1)
+// You can optionally change a hash function, by default it's SHA-256.
+func (g *G1) EncodeToCurve(msg, domain []byte, opts ...HashToFpXMDOpt) (*PointG1, error) {
+	hashRes, err := hashToFpXMD(msg, domain, 1, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -660,8 +661,9 @@ func (g *G1) EncodeToCurve(msg, domain []byte) (*PointG1, error) {
 // which is a valid curve point.
 // Implementation follows BLS12381G1_XMD:SHA-256_SSWU_RO_ suite at
 // https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-06
-func (g *G1) HashToCurve(msg, domain []byte) (*PointG1, error) {
-	hashRes, err := hashToFpXMDSHA256(msg, domain, 2)
+// You can optionally change a hash function, by default it's SHA-256.
+func (g *G1) HashToCurve(msg, domain []byte, opts ...HashToFpXMDOpt) (*PointG1, error) {
+	hashRes, err := hashToFpXMD(msg, domain, 2, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/g1_test.go
+++ b/g1_test.go
@@ -3,6 +3,7 @@ package bls12381
 import (
 	"bytes"
 	"crypto/rand"
+	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -551,7 +552,7 @@ func TestG1HashToCurve(t *testing.T) {
 		},
 	} {
 		g := NewG1()
-		p0, err := g.HashToCurve(v.msg, domain)
+		p0, err := g.HashToCurve(v.msg, domain, WithHashToFpXMDHashFunction(sha256.New))
 		if err != nil {
 			t.Fatal("hash to point fails", i, err)
 		}

--- a/g2.go
+++ b/g2.go
@@ -742,8 +742,9 @@ func (g *G2) MapToCurve(in []byte) (*PointG2, error) {
 // which is a valid curve point.
 // Implementation follows BLS12381G1_XMD:SHA-256_SSWU_NU_ suite at
 // https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-06
-func (g *G2) EncodeToCurve(msg, domain []byte) (*PointG2, error) {
-	hashRes, err := hashToFpXMDSHA256(msg, domain, 2)
+// You can optionally change a hash function, by default it's SHA-256.
+func (g *G2) EncodeToCurve(msg, domain []byte, opts ...HashToFpXMDOpt) (*PointG2, error) {
+	hashRes, err := hashToFpXMD(msg, domain, 2, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -761,8 +762,9 @@ func (g *G2) EncodeToCurve(msg, domain []byte) (*PointG2, error) {
 // which is a valid curve point.
 // Implementation follows BLS12381G1_XMD:SHA-256_SSWU_RO_ suite at
 // https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-06
-func (g *G2) HashToCurve(msg, domain []byte) (*PointG2, error) {
-	hashRes, err := hashToFpXMDSHA256(msg, domain, 4)
+// You can optionally change a hash function, by default it's SHA-256.
+func (g *G2) HashToCurve(msg, domain []byte, opts ...HashToFpXMDOpt) (*PointG2, error) {
+	hashRes, err := hashToFpXMD(msg, domain, 4, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Used kilic#15 as a reference.

We need this hash function configurability because BBS+ signature schema (reference implementation is https://github.com/hyperledger/ursa/tree/master/libzmix/bbs) uses blake2d hash.