### PR TITLE
Support 32-bit architecture

### DIFF
--- a/fr.go
+++ b/fr.go
@@ -81,7 +81,7 @@ func (e *Fr) fromBig(in *big.Int) *Fr {
 		_in.Mod(_in, qBig)
 	}
 
-	words := _in.Bits()
+	words := _in.Bits()  // a little-endian Word slice
 	if bits.UintSize == 64 { // in the 64-bit architecture
 		for i := 0; i < len(words); i++ {
 			e[i] = uint64(words[i])
@@ -89,8 +89,10 @@ func (e *Fr) fromBig(in *big.Int) *Fr {
 	} else { // in the 32-bit architecture
 		for i := 0; i < len(e); i++ {
 			j := i*2
-			if j < len(words) {
-				e[i] = uint64(words[j]<<32 | words[j+1])
+			if j+1 < len(words) {
+				e[i] = uint64(words[j+1])<<32 | uint64(words[j])
+			} else if j < len(words) {
+				e[i] = uint64(words[j])
 			} else {
 				e[i] = uint64(0)
 			}

--- a/fr.go
+++ b/fr.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"io"
 	"math/big"
+	"math/bits"
 )
 
 const frByteSize = 32
@@ -79,10 +80,23 @@ func (e *Fr) fromBig(in *big.Int) *Fr {
 	if c0 == -1 || c1 == 1 {
 		_in.Mod(_in, qBig)
 	}
+
 	words := _in.Bits()
-	for i := 0; i < len(words); i++ {
-		e[i] = uint64(words[i])
+	if bits.UintSize == 64 { // in the 64-bit architecture
+		for i := 0; i < len(words); i++ {
+			e[i] = uint64(words[i])
+		}
+	} else { // in the 32-bit architecture
+		for i := 0; i < len(e); i++ {
+			j := i*2
+			if j < len(words) {
+				e[i] = uint64(words[j]<<32 | words[j+1])
+			} else {
+				e[i] = uint64(0)
+			}
+		}
 	}
+
 	return e
 }
 


### PR DESCRIPTION
@kilic 

In 32-bit architecture, the `fromBig()` in the `fr.go` panics. It works only in the 64-bit architecture, because it assumes that the word size is always 64 bits.

I found this issue when I use the aries-framework-go which uses this library:
https://github.com/hyperledger/aries-framework-go/issues/2758
You can find the detail error message from the link above.

I tested on my [Ubuntu 32bit docker container](https://hub.docker.com/r/i386/ubuntu/) by `go test ./...`.